### PR TITLE
add midwest optical to organizations

### DIFF
--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -846,7 +846,7 @@ class Organization:
             Semrock,
             Thorlabs,
             Other
-        ], 
+        ],
         Field(discriminator="name"),
     ]
     LENS_MANUFACTURERS = Annotated[

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -763,7 +763,7 @@ class Organization:
     LG = Lg()
     LIFECANVAS = LifeCanvas()
     MEADOWLARK = MeadowlarkOptics()
-    MIDWEST_OPTICAL_SYSTEMS = MidwestOpticalSystems()
+    MIDOPT = MidwestOpticalSystems()
     MIGHTY_ZAP = IRRobotCo()
     MITUTUYO = Mitutuyo()
     MKS_NEWPORT = MKSNewport()

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -402,6 +402,15 @@ class IRRobotCo(_Organization):
     registry_identifier: Literal[None] = Field(None)
 
 
+class MidwestOpticalSystems(_Organization):
+    """MidwestOpticalSystems"""
+
+    name: Literal["Midwest Optical Systems, Inc."] = "Midwest Optical Systems, Inc."
+    abbreviation: Literal["MidOpt"] = "MidOpt"
+    registry: Literal[None] = Field(None)
+    registry_identifier: Literal[None] = Field(None)
+
+
 class Mitutuyo(_Organization):
     """Mitutuyo"""
 
@@ -754,6 +763,7 @@ class Organization:
     LG = Lg()
     LIFECANVAS = LifeCanvas()
     MEADOWLARK = MeadowlarkOptics()
+    MIDWEST_OPTICAL_SYSTEMS = MidwestOpticalSystems()
     MIGHTY_ZAP = IRRobotCo()
     MITUTUYO = Mitutuyo()
     MKS_NEWPORT = MKSNewport()
@@ -828,7 +838,17 @@ class Organization:
         ],
         Field(discriminator="name"),
     ]
-    FILTER_MANUFACTURERS = Annotated[Union[Chroma, EdmundOptics, Semrock, Thorlabs, Other], Field(discriminator="name")]
+    FILTER_MANUFACTURERS = Annotated[
+        Union[
+            Chroma,
+            EdmundOptics,
+            MidwestOpticalSystems,
+            Semrock,
+            Thorlabs,
+            Other
+        ], 
+        Field(discriminator="name"),
+    ]
     LENS_MANUFACTURERS = Annotated[
         Union[
             Computar,


### PR DESCRIPTION
closes #5 

Adds the organization `Midwest Optical Systems` to `organizations.py`

Abbr: `MidOpt`
RORID: none

Adds org to list `FILTER_MANUFACTURERS`