### PR TITLE
adding two orgs to laser and lamp models

### DIFF
--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -784,14 +784,6 @@ class CarlZeiss(_Organization):
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
     registry_identifier: Literal["01xk5xs43"] = "01xk5xs43"
 
-class Chameleon(_Organization):
-    """Chameleon"""
-
-    name: Literal["Chameleon"] = "Chameleon"
-    abbreviation: Literal[None] = Field(None)
-    registry: Literal[None] = Field(None)
-    registry_identifier: Literal[None] = Field(None)
-
 class LumenDynamics(_Organization):
     """Lumen Dynamics"""
 
@@ -826,7 +818,6 @@ class Organization:
     CAMBRIDGE_TECHNOLOGY = CambridgeTechnology()
     CHAMPALIMAUD = ChampalimaudFoundation()
     CZI = ChanZuckerbergInitiative()
-    CHAMELEON = Chameleon()
     CHROMA = Chroma()
     COHERENT_SCIENTIFIC = CoherentScientific()
     COLUMBIA = ColumbiaUniversity()
@@ -973,7 +964,7 @@ class Organization:
         Field(discriminator="name"),
     ]
     LASER_MANUFACTURERS = Annotated[
-        Union[CoherentScientific, Hamamatsu, Oxxius, Quantifi, Vortran, Chameleon, Other], Field(discriminator="name")
+        Union[CoherentScientific, Hamamatsu, Oxxius, Quantifi, Vortran, Other], Field(discriminator="name")
     ]
     LED_MANUFACTURERS = Annotated[Union[AmsOsram, Doric, Prizmatix, Thorlabs, Other], Field(discriminator="name")]
     MANIPULATOR_MANUFACTURERS = Annotated[Union[NewScaleTechnologies, Other], Field(discriminator="name")]

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -784,7 +784,21 @@ class CarlZeiss(_Organization):
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
     registry_identifier: Literal["01xk5xs43"] = "01xk5xs43"
 
+class Chameleon(_Organization):
+    """Chameleon"""
 
+    name: Literal["Chameleon"] = "Chameleon"
+    abbreviation: Literal[None] = Field(None)
+    registry: Literal[None] = Field(None)
+    registry_identifier: Literal[None] = Field(None)
+
+class LumenDynamics(_Organization):
+    """Lumen Dynamics"""
+
+    name: Literal["Lumen Dynamics"] = "Lumen Dynamics"
+    abbreviation: Literal[None] = Field(None)
+    registry: Literal[None] = Field(None)
+    registry_identifier: Literal[None] = Field(None)
 class Other(_Organization):
     """Other"""
 
@@ -812,6 +826,7 @@ class Organization:
     CAMBRIDGE_TECHNOLOGY = CambridgeTechnology()
     CHAMPALIMAUD = ChampalimaudFoundation()
     CZI = ChanZuckerbergInitiative()
+    CHAMELEON = Chameleon()
     CHROMA = Chroma()
     COHERENT_SCIENTIFIC = CoherentScientific()
     COLUMBIA = ColumbiaUniversity()
@@ -840,6 +855,7 @@ class Organization:
     LEICA = Leica()
     LG = Lg()
     LIFECANVAS = LifeCanvas()
+    LUMEN_DYNAMICS = LumenDynamics()
     MBF = MBFBioscience()
     MEADOWLARK = MeadowlarkOptics()
     MIDOPT = MidwestOpticalSystems()
@@ -957,7 +973,7 @@ class Organization:
         Field(discriminator="name"),
     ]
     LASER_MANUFACTURERS = Annotated[
-        Union[CoherentScientific, Hamamatsu, Oxxius, Quantifi, Vortran, Other], Field(discriminator="name")
+        Union[CoherentScientific, Hamamatsu, Oxxius, Quantifi, Vortran, Chameleon, Other], Field(discriminator="name")
     ]
     LED_MANUFACTURERS = Annotated[Union[AmsOsram, Doric, Prizmatix, Thorlabs, Other], Field(discriminator="name")]
     MANIPULATOR_MANUFACTURERS = Annotated[Union[NewScaleTechnologies, Other], Field(discriminator="name")]

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -489,6 +489,7 @@ class NationalCenterForComplementaryAndIntegrativeHealth(_Organization):
 
 class NationalInstituteOfMentalHealth(_Organization):
     """NationalInstituteofMentalHealth"""
+
     name: Literal["National Institute of Mental Health"] = "National Institute of Mental Health"
     abbreviation: Literal["NIMH"] = "NIMH"
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
@@ -784,6 +785,7 @@ class CarlZeiss(_Organization):
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
     registry_identifier: Literal["01xk5xs43"] = "01xk5xs43"
 
+
 class LumenDynamics(_Organization):
     """Lumen Dynamics"""
 
@@ -791,6 +793,8 @@ class LumenDynamics(_Organization):
     abbreviation: Literal[None] = Field(None)
     registry: Literal[None] = Field(None)
     registry_identifier: Literal[None] = Field(None)
+
+
 class Other(_Organization):
     """Other"""
 


### PR DESCRIPTION
Mesoscope uses a Chameleon laser and Lumen Dynamics epi lamp. Adding for mesoscope rig json