### PR TITLE
Add IDT to organizations list

### DIFF
--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -302,6 +302,13 @@ class TheImagingSource(_Organization):
     registry: Literal[None] = Field(None)
     registry_identifier: Literal[None] = Field(None)
 
+class IntegratedDNATechnologies(_Organization):
+    """IntegratedDNATechnologies"""
+
+    name: Literal["Integrated DNA Technologies"] = "Integrated DNA Technologies"
+    abbreviation: Literal["IDT"] = "IDT"
+    registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
+    registry_identifier: Literal["009jvpf03"] = "009jvpf03"
 
 class InteruniversityMicroelectronicsCenter(_Organization):
     """InteruniversityMicroelectronicsCenter"""
@@ -831,6 +838,7 @@ class Organization:
     IMAGING_SOURCE = TheImagingSource()
     IMEC = InteruniversityMicroelectronicsCenter()
     INFINITY_PHOTO_OPTICAL = InfinityPhotoOptical()
+    IDT = IntegratedDNATechnologies()
     INVITROGEN = Invitrogen()
     ISL = ISLProductsInternational()
     JAX = JacksonLaboratory()

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -302,6 +302,7 @@ class TheImagingSource(_Organization):
     registry: Literal[None] = Field(None)
     registry_identifier: Literal[None] = Field(None)
 
+
 class IntegratedDNATechnologies(_Organization):
     """IntegratedDNATechnologies"""
 
@@ -309,6 +310,7 @@ class IntegratedDNATechnologies(_Organization):
     abbreviation: Literal["IDT"] = "IDT"
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
     registry_identifier: Literal["009jvpf03"] = "009jvpf03"
+
 
 class InteruniversityMicroelectronicsCenter(_Organization):
     """InteruniversityMicroelectronicsCenter"""
@@ -496,6 +498,7 @@ class NationalCenterForComplementaryAndIntegrativeHealth(_Organization):
 
 class NationalInstituteOfMentalHealth(_Organization):
     """NationalInstituteofMentalHealth"""
+
     name: Literal["National Institute of Mental Health"] = "National Institute of Mental Health"
     abbreviation: Literal["NIMH"] = "NIMH"
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]


### PR DESCRIPTION
closes #28 

Adds:
name: Integrated DNA Technologies
abbreviation: IDT
rorid: https://ror.org/009jvpf03

Currently does not add this to any manufacturer/funder lists