### PR TITLE
feat(platform): add new motor observatory platform

### DIFF
--- a/src/aind_data_schema_models/platforms.py
+++ b/src/aind_data_schema_models/platforms.py
@@ -121,6 +121,13 @@ class SmartSpim(_Platform):
     abbreviation: Literal["SmartSPIM"] = "SmartSPIM"
 
 
+class MotorObservatory(_Platform):
+    """MotorObservatory"""
+
+    name: Literal["Motor observatory platform"] = "Motor observatory platform"
+    abbreviation: Literal["motor-observatory"] = "motor-observatory"
+
+
 class Platform:
     """Platform classes"""
 


### PR DESCRIPTION
This adds motor observatory platform. 

I think it would be useful to have a separate platform to include data from my rig that would combine 3D tracking with either EMG or fiber photometry. 