### PR TITLE
adding EMAPA to registries

### DIFF
--- a/src/aind_data_schema_models/registry.py
+++ b/src/aind_data_schema_models/registry.py
@@ -20,7 +20,7 @@ class Addgene(_Registry):
     abbreviation: Literal["ADDGENE"] = "ADDGENE"
 
 
-class EMAPA(_Registry):
+class EdinburghMouseAtlasProject(_Registry):
     """EMAPA"""
 
     name: Literal["Edinburgh Mouse Atlas Project"] = "Edinburgh Mouse Atlas Project"
@@ -66,7 +66,7 @@ class Registry:
     """Registry definitions"""
 
     ADDGENE = Addgene()
-    EMAPA = EMAPA()
+    EMAPA = EdinburghMouseAtlasProject()
     ROR = ResearchOrganizationRegistry()
     MGI = MouseGenomeInformatics()
     NCBI = NationalCenterForBiotechnologyInformation()

--- a/src/aind_data_schema_models/registry.py
+++ b/src/aind_data_schema_models/registry.py
@@ -20,6 +20,13 @@ class Addgene(_Registry):
     abbreviation: Literal["ADDGENE"] = "ADDGENE"
 
 
+class EMAPA(_Registry):
+    """EMAPA"""
+
+    name: Literal["Edinburgh Mouse Atlas Project"] = "Edinburgh Mouse Atlas Project"
+    abbreviation: Literal["EMAPA"] = "EMAPA"
+
+
 class MouseGenomeInformatics(_Registry):
     """MouseGenomeInformatics"""
 
@@ -59,6 +66,7 @@ class Registry:
     """Registry definitions"""
 
     ADDGENE = Addgene()
+    EMAPA = EMAPA()
     ROR = ResearchOrganizationRegistry()
     MGI = MouseGenomeInformatics()
     NCBI = NationalCenterForBiotechnologyInformation()


### PR DESCRIPTION
closes #39 

Adding to registries: 
name: Edinburgh Mouse Atlas Project
abbreviation: EMAPA