### PR TITLE
fix: update to pydantic minimum 2.7 to avoid annotation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "pydantic>=2.0",
+    "pydantic>=2.7",
     "importlib-resources"
 ]
 


### PR DESCRIPTION
Time boxed attempt to fix this on 2.6.4 didn't work out, bumping minimum version number for pydantic