### PR TITLE
Ensure backwards compatiblity between `ophys` and `pohys` modality

### DIFF
--- a/src/aind_data_schema_models/modalities.py
+++ b/src/aind_data_schema_models/modalities.py
@@ -1,10 +1,21 @@
 """Module for Modality definitions"""
 
+from typing import Any
+
 from importlib_resources import files
-from pydantic import ConfigDict, Field
+from pydantic import BeforeValidator, ConfigDict, Field
 
 from aind_data_schema_models.pid_names import BaseName
 from aind_data_schema_models.utils import create_literal_class, read_csv
+
+
+# This is a hotfix to allow users to use the old ophys modality abbreviation
+# It should be removed in a future release
+def _coerce_ophys_to_pophys(v: Any):
+    if isinstance(v, dict):
+        if v.get("abbreviation") == "ophys":
+            return Modality.POPHYS
+    return v
 
 
 class ModalityModel(BaseName):
@@ -21,6 +32,7 @@ Modality = create_literal_class(
     base_model=ModalityModel,
     discriminator="abbreviation",
     class_module=__name__,
+    validators=[BeforeValidator(_coerce_ophys_to_pophys)],
 )
 
 Modality.abbreviation_map = {m().abbreviation: m() for m in Modality.ALL}

--- a/src/aind_data_schema_models/modalities.py
+++ b/src/aind_data_schema_models/modalities.py
@@ -38,4 +38,12 @@ Modality = create_literal_class(
 Modality.OPHYS = Modality.POPHYS
 
 Modality.abbreviation_map = {m().abbreviation: m() for m in Modality.ALL}
-Modality.from_abbreviation = lambda x: Modality.abbreviation_map.get(x)
+
+
+def _from_abbreviation(cls, v: Any):
+    if v == "ophys":
+        v = "pophys"
+    return cls.abbreviation_map.get(v)
+
+
+Modality.from_abbreviation = lambda x: _from_abbreviation(Modality, x)

--- a/src/aind_data_schema_models/modalities.py
+++ b/src/aind_data_schema_models/modalities.py
@@ -35,5 +35,7 @@ Modality = create_literal_class(
     validators=[BeforeValidator(_coerce_ophys_to_pophys)],
 )
 
+Modality.OPHYS = Modality.POPHYS
+
 Modality.abbreviation_map = {m().abbreviation: m() for m in Modality.ALL}
 Modality.from_abbreviation = lambda x: Modality.abbreviation_map.get(x)

--- a/src/aind_data_schema_models/utils.py
+++ b/src/aind_data_schema_models/utils.py
@@ -129,8 +129,12 @@ def create_literal_class(
     setattr(
         cls,
         "ONE_OF",
-        Annotated[Union[getattr(cls, "ALL")], Field(discriminator=discriminator), *(validators if validators else [])],
-    )  # noqa: F821
+        Annotated[
+            Union[getattr(cls, "ALL")],  # noqa: F821
+            Field(discriminator=discriminator),
+            *(validators if validators else []),
+        ],
+    )
 
     # add the model instances as class variables
     for m in all_models:

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -2,7 +2,15 @@
 
 import unittest
 
+from pydantic import BaseModel
+
 from aind_data_schema_models.modalities import Modality
+
+
+class MockModel(BaseModel):
+    mod1: Modality.ONE_OF
+    mod2: Modality.ONE_OF
+    mod3: Modality.ONE_OF
 
 
 class TestModality(unittest.TestCase):
@@ -12,6 +20,19 @@ class TestModality(unittest.TestCase):
         """Tests modality can be constructed from abbreviation"""
 
         self.assertEqual(Modality.ECEPHYS, Modality.from_abbreviation("ecephys"))
+
+    def test_ophys_to_pophys_coercion(self):
+        """Tests that ophys is coerced to pophys"""
+
+        _test_literal = """
+        {
+        "mod1":{"name":"Extracellular electrophysiology","abbreviation":"ecephys"},
+        "mod2":{"name":"Planar optical physiology","abbreviation":"pophys"},
+        "mod3":{"name":"foo bar","abbreviation":"ophys"}
+        }"""
+        t = MockModel(mod1=Modality.ECEPHYS, mod2=Modality.POPHYS, mod3=Modality.POPHYS)
+
+        self.assertEqual(t, MockModel.model_validate_json(_test_literal))
 
 
 if __name__ == "__main__":

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -44,5 +44,6 @@ class TestModality(unittest.TestCase):
 
         self.assertEqual(Modality.OPHYS, Modality.POPHYS)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -34,6 +34,10 @@ class TestModality(unittest.TestCase):
 
         self.assertEqual(t, MockModel.model_validate_json(_test_literal))
 
+    def test_ophys_attribute(self):
+        """Tests that ophys attribute is available"""
+
+        self.assertEqual(Modality.OPHYS, Modality.POPHYS)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -34,6 +34,11 @@ class TestModality(unittest.TestCase):
 
         self.assertEqual(t, MockModel.model_validate_json(_test_literal))
 
+    def test_ophys_to_pophys_from_abbreviation(self):
+        """Tests that ophys is coerced to pophys from abbreviation"""
+
+        self.assertEqual(Modality.POPHYS, Modality.from_abbreviation("ophys"))
+
     def test_ophys_attribute(self):
         """Tests that ophys attribute is available"""
 


### PR DESCRIPTION
Closes #62 
This PR attempts to
- Ensure that the deserialization of json files using the old "ophys" spec is compatible with the new "pophys" nomenclature.
- Ensure the previous attribute `OPHYS` returns a `Modality.POPHYS` object instead
- Ensure that `from_abbreviation` returns a `POPHYS' object if "ophys" is passed as input

We should consider also adding a deprecation warning each time the validator is called, but I will leave that to one of the maintainers.

Linting will fail since the current head of the repo is not properly sanitized. To prevent contaminating the PR diff,  I would encourage linting after merging the PR.