### PR TITLE
ci: pin aind-flake8-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     'isort',
     'Sphinx',
     'furo',
-    'aind-flake8-extensions',
+    'aind-flake8-extensions==0.5.2',
     'aind-data-access-api[docdb]'
 ]
 


### PR DESCRIPTION
PR pins the version of aind-flake8-extensions so it only warns about missing default= and doesn't add the new extension I put in v0.6.0 (which currently causes the linter tests to fail in aind-data-schema and aind-data-schema-models)