### PR TITLE
perf: remove XValue unit value combinations

### DIFF
--- a/src/aind_data_schema_models/units.py
+++ b/src/aind_data_schema_models/units.py
@@ -129,20 +129,3 @@ class UnitlessUnit(str, Enum):
 
     PERCENT = "percent"
     FC = "fraction of cycle"
-
-
-def create_unit_with_value(model_name, scalar_type, unit_type, unit_default):
-    """this uses create_model instead of generics, which lets us set default values"""
-
-    m = create_model(model_name, value=(scalar_type, ...), unit=(unit_type, unit_default))
-    return m
-
-
-SizeValue = create_unit_with_value("SizeValue", Decimal, SizeUnit, SizeUnit.MM)
-MassValue = create_unit_with_value("MassValue", Decimal, MassUnit, MassUnit.MG)
-VolumeValue = create_unit_with_value("VolumeValue", Decimal, VolumeUnit, VolumeUnit.NL)
-FrequencyValue = create_unit_with_value("FrequencyValue", Decimal, FrequencyUnit, FrequencyUnit.HZ)
-AngleValue = create_unit_with_value("AngleValue", Decimal, AngleUnit, AngleUnit.DEG)
-TimeValue = create_unit_with_value("TimeValue", Decimal, TimeUnit, TimeUnit.S)
-PowerValue = create_unit_with_value("PowerValue", Decimal, PowerUnit, PowerUnit.MW)
-MemoryValue = create_unit_with_value("MemoryValue", Decimal, MemoryUnit, MemoryUnit.GB)

--- a/src/aind_data_schema_models/units.py
+++ b/src/aind_data_schema_models/units.py
@@ -1,9 +1,6 @@
 """Module for defining UnitWithValue classes"""
 
-from decimal import Decimal
 from enum import Enum
-
-from pydantic import create_model
 
 
 class SizeUnit(str, Enum):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -4,7 +4,7 @@ import unittest
 from decimal import Decimal
 from typing import TypeVar
 
-from aind_data_schema_models.units import SizeUnit, SizeValue, create_unit_with_value
+from aind_data_schema_models.units import SizeUnit
 
 ScalarType = TypeVar("ScalarType", Decimal, int)
 
@@ -16,14 +16,6 @@ class UnitsTests(unittest.TestCase):
         """Tests creation of a SizeVal object"""
 
         self.assertIsNotNone(SizeUnit.MM)
-
-        default = SizeValue(value=10.1)
-
-        self.assertEqual(default, SizeValue(value=10.1, unit=SizeUnit.MM))
-
-        ArbitraryValue = create_unit_with_value("ArbitraryValue", Decimal, SizeUnit, SizeUnit.IN)
-
-        self.assertIsNotNone(ArbitraryValue(value=10, unit=SizeUnit.PX))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
BREAKING CHANGE: removes all XValue classes

The intention is to replace these with validators to check that units are included with values

There are only a few places these are being used:
https://github.com/AllenNeuralDynamics/SPIM-UI-Launch/blob/342d357be6aec3798aefe3b6d6ed4d1397678d57/exaSPIM/exaSPIM-UI-Luanch.py#L5
https://github.com/AllenNeuralDynamics/SPIM-UI-Launch/blob/342d357be6aec3798aefe3b6d6ed4d1397678d57/iSPIM/iSPIM-UI-Launch.py#L5

and a few places in aind-data-schema although confusingly it's used in the tests but not in the actual schema?