### PR TITLE
add NBA group for data description

### DIFF
--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -47,6 +47,7 @@ class Group(str, Enum):
     EPHYS = "ephys"
     MSMA = "MSMA"
     OPHYS = "ophys"
+    NBA = "NBA"
 
 
 def datetime_to_name_string(dt: datetime) -> str:


### PR DESCRIPTION
Basically does what it says in the title.

This would allow us to label data from motor observatory and other experiments coming out from the NBA team as group="NBA" in the data description.
