### PR TITLE
Sigma-Aldrich misspelled

### DIFF
--- a/src/aind_data_schema_models/models/organizations.csv
+++ b/src/aind_data_schema_models/models/organizations.csv
@@ -73,7 +73,7 @@ SICGEN,,,
 Schneider-Kreuznach,,,
 Second Order Effects,,,
 Semrock,,,
-Sigma-Aldritch,,,
+Sigma-Aldrich,,,
 Simons Foundation,,ROR,01cmst727
 Spinnaker,,,
 Tamron,,,


### PR DESCRIPTION
closes #90 

Adjusts spelling from `Sigma-Aldritch` -> `Sigma-Aldrich`