### PR TITLE
refactor: update to/from datename to isoformat compatible pattern

### DIFF
--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -83,7 +83,7 @@ def datetime_to_name_string(dt: datetime) -> str:
 
 def datetime_from_name_string(d: str, t: str) -> datetime:
     """
-    DEPRECATED
+    DEPRECATED: Use datetime.fromisoformat() instead.
 
     Take date and time strings, generate datetime object
     Parameters

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -13,24 +13,27 @@ class RegexParts(str, Enum):
     DATETIME = r"\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}"
 
 
-class DataRegex(str, Enum):
-    """Regular expression patterns for different kinds of data and their properties"""
-
+class DataRegexLegacy(str, Enum):
+    """Deprecated regular expression patterns from aind-data-schema-models v1 and earlier"""
     # Deprecated patterns, keeping for legacy support
-    DATA_OLD = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
-    RAW_OLD = (
+    DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
+    RAW = (
         f"^(?P<platform_abbreviation>.+?)_(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>"
         f"{RegexParts.TIME.value})$"
     )
-    DERIVED_OLD = (
+    DERIVED = (
         f"^(?P<input>.+?_{RegexParts.DATE.value}_{RegexParts.TIME.value})_(?P<process_name>.+?)_(?P<c_date>"
         f"{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})"
     )
-    ANALYZED_OLD = (
+    ANALYZED = (
         f"^(?P<project_abbreviation>.+?)_(?P<analysis_name>.+?)_(?P<c_date>"
         f"{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
     )
-    # New patterns
+
+
+class DataRegex(str, Enum):
+    """Regular expression patterns for different kinds of data and their properties"""
+
     DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
     RAW = (
         f"^(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -16,8 +16,8 @@ class RegexParts(str, Enum):
 class DataRegex(str, Enum):
     """Regular expression patterns for different kinds of data and their properties"""
 
+    # Deprecated patterns, keeping for legacy support
     DATA_OLD = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
-    DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
     RAW_OLD = (
         f"^(?P<platform_abbreviation>.+?)_(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>"
         f"{RegexParts.TIME.value})$"
@@ -30,8 +30,10 @@ class DataRegex(str, Enum):
         f"^(?P<project_abbreviation>.+?)_(?P<analysis_name>.+?)_(?P<c_date>"
         f"{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
     )
+    # New patterns
+    DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
     RAW = (
-        f"^(?P<platform_abbreviation>.+?)_(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
+        f"^(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
     )
     DERIVED = (
         f"^(?P<input>.+?_{RegexParts.DATETIME.value})_(?P<process_name>.+?)_(?P<c_date>"
@@ -66,16 +68,17 @@ class Group(str, Enum):
 
 def datetime_to_name_string(dt: datetime) -> str:
     """
-    Take a datetime object, format it as a string
+    Take a datetime object, format it as an ISO-compatible string
+
     Parameters
     ----------
     dt : datetime
-      For example, datetime(2020, 12, 29, 10, 04, 59, 567000)
+      For example, datetime(2020, 12, 29, 10, 04, 59)
 
     Returns
     -------
     str
-      For example, '2020-12-29T100459.567'
+      For example, '2020-12-29T100459'
 
     """
     return dt.strftime("%Y-%m-%dT%H%M%S")
@@ -105,13 +108,13 @@ def datetime_from_name_string(d: str, t: str) -> datetime:
     return datetime.combine(d, t)
 
 
-def build_data_name(subject_id: str, creation_datetime: datetime) -> str:
+def build_data_name(label: str, creation_datetime: datetime) -> str:
     """
     Construct a data description name from a label and datetime object
     Parameters
     ----------
-    subject_id : str
-      For example, '123456'
+    label : str
+      For example a subject_id, '123456'
     creation_datetime : datetime
       For example, datetime(2020, 12, 29, 10, 04, 59)
 
@@ -122,4 +125,4 @@ def build_data_name(subject_id: str, creation_datetime: datetime) -> str:
 
     """
     dt_str = datetime_to_name_string(creation_datetime)
-    return f"{subject_id}_{dt_str}"
+    return f"{label}_{dt_str}"

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
+import warnings
 
 
 class RegexParts(str, Enum):
@@ -9,23 +10,36 @@ class RegexParts(str, Enum):
 
     DATE = r"\d{4}-\d{2}-\d{2}"
     TIME = r"\d{2}-\d{2}-\d{2}"
+    DATETIME = r"\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}"
 
 
 class DataRegex(str, Enum):
     """Regular expression patterns for different kinds of data and their properties"""
 
-    DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
-    RAW = (
+    DATA_OLD = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
+    DATA = f"^(?P<label>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
+    RAW_OLD = (
         f"^(?P<platform_abbreviation>.+?)_(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATE.value})_(?P<c_time>"
         f"{RegexParts.TIME.value})$"
     )
-    DERIVED = (
+    DERIVED_OLD = (
         f"^(?P<input>.+?_{RegexParts.DATE.value}_{RegexParts.TIME.value})_(?P<process_name>.+?)_(?P<c_date>"
         f"{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})"
     )
-    ANALYZED = (
+    ANALYZED_OLD = (
         f"^(?P<project_abbreviation>.+?)_(?P<analysis_name>.+?)_(?P<c_date>"
         f"{RegexParts.DATE.value})_(?P<c_time>{RegexParts.TIME.value})$"
+    )
+    RAW = (
+        f"^(?P<platform_abbreviation>.+?)_(?P<subject_id>.+?)_(?P<c_date>{RegexParts.DATETIME.value})$"
+    )
+    DERIVED = (
+        f"^(?P<input>.+?_{RegexParts.DATETIME.value})_(?P<process_name>.+?)_(?P<c_date>"
+        f"{RegexParts.DATETIME.value})"
+    )
+    ANALYZED = (
+        f"^(?P<project_abbreviation>.+?)_(?P<analysis_name>.+?)_(?P<c_date>"
+        f"{RegexParts.DATETIME.value})$"
     )
     NO_UNDERSCORES = r"^[^_]+$"
     NO_SPECIAL_CHARS = r'^[^<>:;"/|? \\_]+$'
@@ -56,19 +70,21 @@ def datetime_to_name_string(dt: datetime) -> str:
     Parameters
     ----------
     dt : datetime
-      For example, datetime(2020, 12, 29, 10, 04, 59)
+      For example, datetime(2020, 12, 29, 10, 04, 59, 567000)
 
     Returns
     -------
     str
-      For example, '2020-12-29_10-04-59'
+      For example, '2020-12-29T100459.567'
 
     """
-    return dt.strftime("%Y-%m-%d_%H-%M-%S")
+    return dt.strftime("%Y-%m-%dT%H%M%S")
 
 
 def datetime_from_name_string(d: str, t: str) -> datetime:
     """
+    DEPRECATED
+
     Take date and time strings, generate datetime object
     Parameters
     ----------
@@ -82,26 +98,27 @@ def datetime_from_name_string(d: str, t: str) -> datetime:
     datetime
 
     """
+    warnings.warn("This function is deprecated. Use datetime.fromisoformat() instead.")
     d = datetime.strptime(d, "%Y-%m-%d").date()
     t = datetime.strptime(t, "%H-%M-%S").time()
     return datetime.combine(d, t)
 
 
-def build_data_name(label: str, creation_datetime: datetime) -> str:
+def build_data_name(subject_id: str, creation_datetime: datetime) -> str:
     """
     Construct a data description name from a label and datetime object
     Parameters
     ----------
-    label : str
-      For example, 'ecephys_123456'
+    subject_id : str
+      For example, '123456'
     creation_datetime : datetime
       For example, datetime(2020, 12, 29, 10, 04, 59)
 
     Returns
     -------
     str
-      For example, 'ecephys_123456_2020-12-29_10-04-59'
+      For example, '123456_2020-12-29T100459'
 
     """
     dt_str = datetime_to_name_string(creation_datetime)
-    return f"{label}_{dt_str}"
+    return f"{subject_id}_{dt_str}"

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -98,7 +98,8 @@ def datetime_from_name_string(d: str, t: str) -> datetime:
     datetime
 
     """
-    warnings.warn("This function is deprecated. Use datetime.fromisoformat() instead.")
+    warnings.warn("This function is deprecated. Use datetime.fromisoformat() instead.",
+                  DeprecationWarning)
     d = datetime.strptime(d, "%Y-%m-%d").date()
     t = datetime.strptime(t, "%H-%M-%S").time()
     return datetime.combine(d, t)

--- a/tests/test_data_name_patterns.py
+++ b/tests/test_data_name_patterns.py
@@ -7,7 +7,6 @@ from aind_data_schema_models.data_name_patterns import (
     DataRegex,
     RegexParts,
     build_data_name,
-    datetime_from_name_string,
     datetime_to_name_string,
 )
 
@@ -20,18 +19,23 @@ class TestRegexParts(unittest.TestCase):
 
         input_date = "2020-10-19"
         input_time = "08-30-59"
+        input_datetime = "2020-10-19T083059"
 
         self.assertRegex(input_date, RegexParts.DATE)
         self.assertRegex(input_time, RegexParts.TIME)
+        self.assertRegex(input_datetime, RegexParts.DATETIME)
+        self.assertIsNotNone(datetime.fromisoformat(input_datetime))
 
     def test_patterns_fail(self):
         """Tests that the regex patterns match unsuccessfully."""
 
         malformed_date = "10/19/2020"
         malformed_time = "8:30:59"
+        malformed_datetime = "2020-10-19_08-30-59"
 
         self.assertNotRegex(malformed_date, RegexParts.DATE)
         self.assertNotRegex(malformed_time, RegexParts.TIME)
+        self.assertRaises(ValueError, datetime.fromisoformat, malformed_datetime)
 
 
 class TestDataRegex(unittest.TestCase):
@@ -48,21 +52,31 @@ class TestDataRegex(unittest.TestCase):
         no_special_chars = "abc-123"
         no_special_chars_except_space = "abc efg - 123"
 
-        self.assertRegex(data, DataRegex.DATA)
-        self.assertRegex(raw, DataRegex.RAW)
-        self.assertRegex(derived, DataRegex.DERIVED)
-        self.assertRegex(analyzed, DataRegex.ANALYZED)
+        data_dt = "ecephys_2020-10-19T083059"
+        raw_dt = "ecephys_123455_2020-10-19T083059"
+        derived_dt = "ecephys_123455_2020-10-19T083059_sorted_2020-11-21T093158"
+        analyzed_dt = "project_analysis_3033-12-21T042211"
+
+        self.assertRegex(data, DataRegex.DATA_OLD)
+        self.assertRegex(raw, DataRegex.RAW_OLD)
+        self.assertRegex(derived, DataRegex.DERIVED_OLD)
+        self.assertRegex(analyzed, DataRegex.ANALYZED_OLD)
         self.assertRegex(no_underscores, DataRegex.NO_UNDERSCORES)
         self.assertRegex(no_special_chars, DataRegex.NO_SPECIAL_CHARS)
         self.assertRegex(no_special_chars_except_space, DataRegex.NO_SPECIAL_CHARS_EXCEPT_SPACE)
 
+        self.assertRegex(data_dt, DataRegex.DATA)
+        self.assertRegex(raw_dt, DataRegex.RAW)
+        self.assertRegex(derived_dt, DataRegex.DERIVED)
+        self.assertRegex(analyzed_dt, DataRegex.ANALYZED)
+
     def test_patterns_fail(self):
         """Tests that the regex patterns match unsuccessfully."""
 
-        malformed_data = "ecephys_2020-10-19_08:30:59"
-        malformed_raw = "ecephys_123455_2020-10-19_08-30-59_test"
-        malformed_derived = "ecephys_123455_2020-10-19_08-30-59_sorted_2020-11-21_09:31:58"
-        malformed_analyzed = "project_analysis_3033-12-21_04-22-11_test"
+        malformed_data = "ecephys_2020-10-19T08:30:59"
+        malformed_raw = "ecephys_123455_2020-10-19T083059_test"
+        malformed_derived = "ecephys_123455_2020-10-19T083059_sorted_2020-11-21T09:31:58"
+        malformed_analyzed = "project_analysis_3033-12-21T042211_test"
         malformed_no_underscores = "abc_123<something>"
         special_chars = [
             "<",
@@ -79,9 +93,9 @@ class TestDataRegex(unittest.TestCase):
         ]
 
         self.assertNotRegex(malformed_data, DataRegex.DATA)
-        self.assertNotRegex(malformed_raw, DataRegex.RAW)
-        self.assertNotRegex(malformed_derived, DataRegex.DERIVED)
-        self.assertNotRegex(malformed_analyzed, DataRegex.ANALYZED)
+        self.assertNotRegex(malformed_raw, DataRegex.DATA)
+        self.assertNotRegex(malformed_derived, DataRegex.DATA)
+        self.assertNotRegex(malformed_analyzed, DataRegex.DATA)
         self.assertNotRegex(malformed_no_underscores, DataRegex.NO_UNDERSCORES)
         for c in special_chars:
             malformed_no_special_chars = f"abc-123{c}something{c}"
@@ -100,32 +114,31 @@ class TestDataNamePatternsMethods(unittest.TestCase):
 
         dt = datetime(2020, 12, 29, 1, 10, 50)
         actual_output = datetime_to_name_string(dt)
-        self.assertEqual("2020-12-29_01-10-50", actual_output)
+        self.assertEqual("2020-12-29T011050", actual_output)
 
     def test_datetime_with_tz_to_name_string(self):
         """Tests datetime object with timezone is converted to string"""
 
         dt = datetime(2020, 12, 29, 1, 10, 50, tzinfo=timezone.utc)
         actual_output = datetime_to_name_string(dt)
-        self.assertEqual("2020-12-29_01-10-50", actual_output)
+        self.assertEqual("2020-12-29T011050", actual_output)
 
     def test_datetime_from_name_string(self):
         """Tests date and time strings are converted to datetime object"""
 
-        input_date_str = "2020-12-29"
-        input_time_str = "01-10-50"
-        actual_output = datetime_from_name_string(d=input_date_str, t=input_time_str)
+        datetime_str = "2020-12-29T011050"
+        actual_output = datetime.fromisoformat(datetime_str)
         dt = datetime(2020, 12, 29, 1, 10, 50)
         self.assertEqual(dt, actual_output)
 
     def test_build_data_name(self):
         """Tests datetime object is converted to string and attached to label"""
 
-        label = "ecephys_123456"
+        subject_id = "123456"
         dt = datetime(2020, 12, 29, 1, 10, 50)
-        actual_output = build_data_name(label=label, creation_datetime=dt)
+        actual_output = build_data_name(subject_id=subject_id, creation_datetime=dt)
 
-        self.assertEqual("ecephys_123456_2020-12-29_01-10-50", actual_output)
+        self.assertEqual("123456_2020-12-29T011050", actual_output)
 
 
 if __name__ == "__main__":

--- a/tests/test_data_name_patterns.py
+++ b/tests/test_data_name_patterns.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from aind_data_schema_models.data_name_patterns import (
     DataRegex,
+    DataRegexLegacy,
     RegexParts,
     build_data_name,
     datetime_from_name_string,
@@ -58,10 +59,10 @@ class TestDataRegex(unittest.TestCase):
         derived_dt = "ecephys_123455_2020-10-19T083059_sorted_2020-11-21T093158"
         analyzed_dt = "project_analysis_3033-12-21T042211"
 
-        self.assertRegex(data, DataRegex.DATA_OLD)
-        self.assertRegex(raw, DataRegex.RAW_OLD)
-        self.assertRegex(derived, DataRegex.DERIVED_OLD)
-        self.assertRegex(analyzed, DataRegex.ANALYZED_OLD)
+        self.assertRegex(data, DataRegexLegacy.DATA)
+        self.assertRegex(raw, DataRegexLegacy.RAW)
+        self.assertRegex(derived, DataRegexLegacy.DERIVED)
+        self.assertRegex(analyzed, DataRegexLegacy.ANALYZED)
         self.assertRegex(no_underscores, DataRegex.NO_UNDERSCORES)
         self.assertRegex(no_special_chars, DataRegex.NO_SPECIAL_CHARS)
         self.assertRegex(no_special_chars_except_space, DataRegex.NO_SPECIAL_CHARS_EXCEPT_SPACE)
@@ -143,7 +144,7 @@ class TestDataNamePatternsMethods(unittest.TestCase):
 
         subject_id = "123456"
         dt = datetime(2020, 12, 29, 1, 10, 50)
-        actual_output = build_data_name(subject_id=subject_id, creation_datetime=dt)
+        actual_output = build_data_name(label=subject_id, creation_datetime=dt)
 
         self.assertEqual("123456_2020-12-29T011050", actual_output)
 

--- a/tests/test_data_name_patterns.py
+++ b/tests/test_data_name_patterns.py
@@ -7,6 +7,7 @@ from aind_data_schema_models.data_name_patterns import (
     DataRegex,
     RegexParts,
     build_data_name,
+    datetime_from_name_string,
     datetime_to_name_string,
 )
 
@@ -130,6 +131,12 @@ class TestDataNamePatternsMethods(unittest.TestCase):
         actual_output = datetime.fromisoformat(datetime_str)
         dt = datetime(2020, 12, 29, 1, 10, 50)
         self.assertEqual(dt, actual_output)
+
+    def test_deprecated_warning(self):
+        """Tests warning is raised for deprecated method"""
+
+        with self.assertWarns(DeprecationWarning):
+            datetime_from_name_string(d="2020-12-29", t="01-10-50")
 
     def test_build_data_name(self):
         """Tests datetime object is converted to string and attached to label"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,6 +95,7 @@ class LiteralAndDefaultTests(unittest.TestCase):
         # generate a model from the class
         class TestModel(BaseModel):
             """test class"""
+
             structure: MouseAnatomyModel = MouseAnatomy.ANATOMICAL_STRUCTURE
 
         test = TestModel()
@@ -103,6 +104,7 @@ class LiteralAndDefaultTests(unittest.TestCase):
         # generate a test model using the emg group
         class TestModel2(BaseModel):
             """test class"""
+
             structure: MouseAnatomyModel = MouseEmgMuscles.DELTOID
 
         test = TestModel2()


### PR DESCRIPTION
This PR updates the `date_name_patterns.datetime_to_name_string` function to use the new pattern `YYYY-MM-DDTHHMMSS`. It also deprecates the `datetime_from_name_string` function in favor of using `datetime.fromisoformat`

It also updates the data name to the pattern `<subject_id>_<datetime>` instead of `<label>_<date>_<time>`