### PR TITLE
refactor: move unique_rows function to dev_utils, remove pandas depen…

### DIFF
--- a/src/aind_data_schema_models/_generators/dev_utils.py
+++ b/src/aind_data_schema_models/_generators/dev_utils.py
@@ -1,0 +1,22 @@
+""" Dev utilities for constructing models from CSV files """
+
+import pandas as pd
+
+
+def unique_rows(value, key):
+    """Generate a unique subset of a dataframe based on a key column.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+      The data to filter.
+    key : str
+      The column to filter on.
+    """
+    seen = set()
+    unique_rows = []
+    for _, row in value.iterrows():
+        if row[key] not in seen:
+            seen.add(row[key])
+            unique_rows.append(row)
+    return pd.DataFrame(unique_rows)

--- a/src/aind_data_schema_models/_generators/generator.py
+++ b/src/aind_data_schema_models/_generators/generator.py
@@ -2,7 +2,8 @@
 import argparse
 from jinja2 import Environment
 import pandas as pd
-from aind_data_schema_models.utils import to_class_name, to_class_name_underscored, unique_rows
+from aind_data_schema_models.utils import to_class_name, to_class_name_underscored
+from aind_data_schema_models._generators.dev_utils import unique_rows
 from pathlib import Path
 import subprocess
 

--- a/src/aind_data_schema_models/utils.py
+++ b/src/aind_data_schema_models/utils.py
@@ -4,26 +4,6 @@ import re
 from pydantic import BaseModel, Field
 from typing import Union, List, Type, Any
 from typing_extensions import Annotated
-import pandas as pd
-
-
-def unique_rows(value, key):
-    """Generate a unique subset of a dataframe based on a key column.
-    
-    Parameters
-    ----------
-    data : pd.DataFrame
-      The data to filter.
-    key : str
-      The column to filter on.
-    """
-    seen = set()
-    unique_rows = []
-    for _, row in value.iterrows():
-        if row[key] not in seen:
-            seen.add(row[key])
-            unique_rows.append(row)
-    return pd.DataFrame(unique_rows)
 
 
 def to_class_name_underscored(name: str) -> str:


### PR DESCRIPTION
This PR fixes a bug where the `pandas` package was added as a dependency to the `utils.py` file, which is used in the released package. The dependency has now been moved to a `dev_utils.py` file in the _generators/ folder. 