### PR TITLE
fix: add AIND to funders list

### DIFF
--- a/src/aind_data_schema_models/_generators/templates/organizations.txt
+++ b/src/aind_data_schema_models/_generators/templates/organizations.txt
@@ -140,6 +140,7 @@ Organization.SPEAKER_MANUFACTURERS = one_of_instance(
 Organization.FUNDERS = one_of_instance(
     [
         Organization.AI,
+        Organization.AIND,
         Organization.CZI,
         Organization.MBF,
         Organization.MJFF,

--- a/src/aind_data_schema_models/organizations.py
+++ b/src/aind_data_schema_models/organizations.py
@@ -1,4 +1,5 @@
 """Organizations"""
+
 from typing import Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -498,9 +499,9 @@ class _Meadowlark_Optics(_OrganizationModel):
 class _Michael_J_Fox_Foundation_For_Parkinson_S_Research(_OrganizationModel):
     """Model Michael J. Fox Foundation for Parkinson's Research"""
 
-    name: Literal[
+    name: Literal["Michael J. Fox Foundation for Parkinson's Research"] = (
         "Michael J. Fox Foundation for Parkinson's Research"
-    ] = "Michael J. Fox Foundation for Parkinson's Research"
+    )
     abbreviation: Literal["MJFF"] = "MJFF"
     registry: Registry.ONE_OF = Registry.ROR
     registry_identifier: Literal["03arq3225"] = "03arq3225"
@@ -536,9 +537,9 @@ class _Nresearch_Inc(_OrganizationModel):
 class _National_Center_For_Complementary_And_Integrative_Health(_OrganizationModel):
     """Model National Center for Complementary and Integrative Health"""
 
-    name: Literal[
+    name: Literal["National Center for Complementary and Integrative Health"] = (
         "National Center for Complementary and Integrative Health"
-    ] = "National Center for Complementary and Integrative Health"
+    )
     abbreviation: Literal["NCCIH"] = "NCCIH"
     registry: Registry.ONE_OF = Registry.ROR
     registry_identifier: Literal["00190t495"] = "00190t495"
@@ -556,9 +557,9 @@ class _National_Institute_Of_Mental_Health(_OrganizationModel):
 class _National_Institute_Of_Neurological_Disorders_And_Stroke(_OrganizationModel):
     """Model National Institute of Neurological Disorders and Stroke"""
 
-    name: Literal[
+    name: Literal["National Institute of Neurological Disorders and Stroke"] = (
         "National Institute of Neurological Disorders and Stroke"
-    ] = "National Institute of Neurological Disorders and Stroke"
+    )
     abbreviation: Literal["NINDS"] = "NINDS"
     registry: Registry.ONE_OF = Registry.ROR
     registry_identifier: Literal["01s5ya894"] = "01s5ya894"
@@ -1094,6 +1095,7 @@ Organization.SPEAKER_MANUFACTURERS = one_of_instance(
 Organization.FUNDERS = one_of_instance(
     [
         Organization.AI,
+        Organization.AIND,
         Organization.CZI,
         Organization.MBF,
         Organization.MJFF,


### PR DESCRIPTION
This PR adds `Organization.AIND` to the `Organization.FUNDERS` Union. Currently DataDescription object validation fails for several hundred data assets because this organization is missing from the list. 