### PR TITLE
feat: add injection targets (RO and IP injections)

### DIFF
--- a/src/aind_data_schema_models/_generators/templates/mouse_anatomy.txt
+++ b/src/aind_data_schema_models/_generators/templates/mouse_anatomy.txt
@@ -173,3 +173,9 @@ class MouseBloodVessels(metaclass=MouseAnatomyMeta):
 
     CAROTID_ARTERY = "carotid artery"
     JUGULAR_VEIN = "jugular vein"
+
+class InjectionTargets(metaclass=MouseAnatomyMeta):
+    """ Common injection targets """
+
+    VENOUS_SINUS = "venous sinus"
+    PERITONEAL_CAVITY = "peritoneal cavity"

--- a/src/aind_data_schema_models/mouse_anatomy.py
+++ b/src/aind_data_schema_models/mouse_anatomy.py
@@ -8398,3 +8398,10 @@ class MouseBloodVessels(metaclass=MouseAnatomyMeta):
 
     CAROTID_ARTERY = "carotid artery"
     JUGULAR_VEIN = "jugular vein"
+
+
+class InjectionTargets(metaclass=MouseAnatomyMeta):
+    """Common injection targets"""
+
+    VENOUS_SINUS = "venous sinus"
+    PERITONEAL_CAVITY = "peritoneal cavity"


### PR DESCRIPTION
This PR adds common injection targets, to simplify targeting in the `Procedures.Injection` class when targeting parts of the body