### PR TITLE
feat: set a lower bound on the version of the black package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     'codespell',
-    'black',
+    'black>=25.0.0',
     'coverage',
     'flake8',
     'interrogate',

--- a/src/aind_data_schema_models/_generators/dev_utils.py
+++ b/src/aind_data_schema_models/_generators/dev_utils.py
@@ -1,4 +1,4 @@
-""" Dev utilities for constructing models from CSV files """
+"""Dev utilities for constructing models from CSV files"""
 
 import re
 

--- a/src/aind_data_schema_models/_generators/generator.py
+++ b/src/aind_data_schema_models/_generators/generator.py
@@ -10,16 +10,10 @@ import subprocess
 
 def check_black_version():
     """ Check that the version of the black package is >= 25.0.0 """
-
-    try:
-        import black
-        from packaging import version
-        assert version.parse(black.__version__) >= version.parse("25.0.0")
-    except AssertionError:
-        print("Please upgrade the black package to version 25.0.0 or later.")
-        print("You can upgrade it with the following command:")
-        print("pip install -U black")
-        exit(1)
+    import black
+    from packaging import version
+    if version.parse(black.__version__) < version.parse("25.0.0"):
+        raise AssertionError("Please upgrade the black package to version 25.0.0 or later.")
 
 
 def generate_code(data_type: str, root_path: str, isort: bool = True, black: bool = True):

--- a/src/aind_data_schema_models/_generators/generator.py
+++ b/src/aind_data_schema_models/_generators/generator.py
@@ -9,9 +9,10 @@ import subprocess
 
 
 def check_black_version():
-    """ Check that the version of the black package is >= 25.0.0 """
+    """Check that the version of the black package is >= 25.0.0"""
     import black
     from packaging import version
+
     if version.parse(black.__version__) < version.parse("25.0.0"):
         raise AssertionError("Please upgrade the black package to version 25.0.0 or later.")
 

--- a/src/aind_data_schema_models/_generators/generator.py
+++ b/src/aind_data_schema_models/_generators/generator.py
@@ -8,6 +8,20 @@ from pathlib import Path
 import subprocess
 
 
+def check_black_version():
+    """ Check that the version of the black package is >= 25.0.0 """
+
+    try:
+        import black
+        from packaging import version
+        assert version.parse(black.__version__) >= version.parse("25.0.0")
+    except AssertionError:
+        print("Please upgrade the black package to version 25.0.0 or later.")
+        print("You can upgrade it with the following command:")
+        print("pip install -U black")
+        exit(1)
+
+
 def generate_code(data_type: str, root_path: str, isort: bool = True, black: bool = True):
     """Generate code from the template type
 
@@ -20,6 +34,7 @@ def generate_code(data_type: str, root_path: str, isort: bool = True, black: boo
     black : bool, optional
         Whether to run black on the output, by default True
     """
+
     ROOT_DIR = Path(root_path)
     data_file = ROOT_DIR / "_generators" / "models" / f"{data_type}.csv"
     template_file = ROOT_DIR / "_generators" / "templates" / f"{data_type}.txt"
@@ -57,6 +72,8 @@ def generate_code(data_type: str, root_path: str, isort: bool = True, black: boo
 
 
 if __name__ == "__main__":
+    check_black_version()
+
     parser = argparse.ArgumentParser(description="Generate code from templates.")
     parser.add_argument("--type", required=True, help="The data type to generate code for (e.g., 'platforms').")
     parser.add_argument(

--- a/src/aind_data_schema_models/utils.py
+++ b/src/aind_data_schema_models/utils.py
@@ -1,4 +1,4 @@
-""" General utilities for constructing models from CSV files """
+"""General utilities for constructing models from CSV files"""
 
 from pydantic import BaseModel, Field
 from typing import Union, List, Type, Any

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch, mock_open, MagicMock
 from pathlib import Path
 import pandas as pd
-from aind_data_schema_models._generators.generator import generate_code
+from aind_data_schema_models._generators.generator import generate_code, check_black_version
 import os
 
 
@@ -89,6 +89,19 @@ class TestGenerateCode(unittest.TestCase):
         # Run the function expecting a FileNotFoundError due to missing template file
         with self.assertRaises(FileNotFoundError):
             generate_code("missing_template", root_path=ROOT_DIR)
+
+    def test_check_black_version_too_old(self):
+        """Test check_black_version when black version is too old"""
+        with patch("black.__version__", "24.0.0"):
+            with self.assertRaises(AssertionError) as context:
+                check_black_version()
+
+            self.assertIn("Please upgrade the black package to version 25.0.0 or later.", str(context.exception))
+
+    def test_check_black_version_valid(self):
+        """Test check_black_version when black version is valid"""
+        with patch("black.__version__", "25.0.0"):
+            check_black_version()
 
 
 if __name__ == "__main__":

--- a/tests/test_pid_names.py
+++ b/tests/test_pid_names.py
@@ -1,4 +1,4 @@
-"""Tests classes in pid_names """
+"""Tests classes in pid_names"""
 
 import unittest
 


### PR DESCRIPTION
This PR sets a lower bound on the version of the package `black` and enforces it in the generator code. Users can no longer call the main run script without a compatible version.

Apparently nobody has run black on the src/ folder in a while because it also wanted to change a few docstrings.