### PR TITLE
feat: add an origin concept for AnatomicalRelative

### DIFF
--- a/src/aind_data_schema_models/coordinates.py
+++ b/src/aind_data_schema_models/coordinates.py
@@ -65,3 +65,4 @@ class AnatomicalRelative(str, Enum):
     RIGHT = "Right"
     MEDIAL = "Medial"
     LATERAL = "Lateral"
+    ORIGIN = "Origin"  # on the origin


### PR DESCRIPTION
PR adds `AnatomicalRelative.ORIGIN` for use in situations where an object or position is on the origin but we require users to specify an `AnatomicalRelative` position.