### PR TITLE
breaking change: Revert datetime pattern and change direction bottom_to_top to down_to_up

### DIFF
--- a/src/aind_data_schema_models/coordinates.py
+++ b/src/aind_data_schema_models/coordinates.py
@@ -48,10 +48,11 @@ class Direction(str, Enum):
     SI = "Superior_to_inferior"
     FB = "Front_to_back"
     BF = "Back_to_front"
-    TB = "Top_to_bottom"
-    BT = "Bottom_to_top"
+    UD = "Up_to_down"
+    DU = "Down_to_up"
     OTHER = "Other"
     POS = "Positive"
+    NEG = "Negative"
 
 
 class AnatomicalRelative(str, Enum):

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -66,7 +66,7 @@ class Group(str, Enum):
 
 def datetime_to_name_string(dt: datetime) -> str:
     """
-    Take a datetime object, format it as a legaxy AIND datetime string
+    Take a datetime object, format it as a legacy AIND datetime string
 
     Parameters
     ----------

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -11,7 +11,7 @@ class RegexParts(str, Enum):
 
     DATE = r"\d{4}-\d{2}-\d{2}"
     TIME = r"\d{2}-\d{2}-\d{2}"
-    DATETIME = r"\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}"
+    DATETIME = r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}"
 
 
 class DataRegexLegacy(str, Enum):
@@ -68,7 +68,7 @@ class Group(str, Enum):
 
 def datetime_to_name_string(dt: datetime) -> str:
     """
-    Take a datetime object, format it as an ISO-compatible string
+    Take a datetime object, format it as a legaxy AIND datetime string
 
     Parameters
     ----------
@@ -78,10 +78,10 @@ def datetime_to_name_string(dt: datetime) -> str:
     Returns
     -------
     str
-      For example, '2020-12-29T100459'
+      For example, '2020-12-29_10-04-59'
 
     """
-    return dt.strftime("%Y-%m-%dT%H%M%S")
+    return dt.strftime("%Y-%m-%d_%H-%M-%S")
 
 
 def datetime_from_name_string(dt: str) -> datetime:
@@ -95,11 +95,7 @@ def datetime_from_name_string(dt: str) -> datetime:
     datetime
 
     """
-    if sys.version_info.minor > 10:
-        warnings.warn("Use datetime.fromisoformat() instead.", DeprecationWarning)
-        return datetime.fromisoformat(dt)
-    else:
-        return datetime.strptime(dt, "%Y-%m-%dT%H%M%S")
+    return datetime.strptime(dt, "%Y-%m-%d_%H-%M-%S")
 
 
 def build_data_name(label: str, creation_datetime: datetime) -> str:
@@ -115,7 +111,7 @@ def build_data_name(label: str, creation_datetime: datetime) -> str:
     Returns
     -------
     str
-      For example, '123456_2020-12-29T100459'
+      For example, '123456_2020-12-29_10-04-59'
 
     """
     dt_str = datetime_to_name_string(creation_datetime)

--- a/src/aind_data_schema_models/data_name_patterns.py
+++ b/src/aind_data_schema_models/data_name_patterns.py
@@ -2,8 +2,6 @@
 
 from datetime import datetime
 from enum import Enum
-import warnings
-import sys
 
 
 class RegexParts(str, Enum):

--- a/tests/test_data_name_patterns.py
+++ b/tests/test_data_name_patterns.py
@@ -1,7 +1,6 @@
 """Tests classes in data_name_patterns module"""
 
 import unittest
-import sys
 from datetime import datetime, timezone
 
 from aind_data_schema_models.data_name_patterns import (

--- a/tests/test_data_name_patterns.py
+++ b/tests/test_data_name_patterns.py
@@ -22,7 +22,7 @@ class TestRegexParts(unittest.TestCase):
 
         input_date = "2020-10-19"
         input_time = "08-30-59"
-        input_datetime = "2020-10-19T083059"
+        input_datetime = "2020-10-19_08-30-59"
 
         self.assertRegex(input_date, RegexParts.DATE)
         self.assertRegex(input_time, RegexParts.TIME)
@@ -53,10 +53,10 @@ class TestDataRegex(unittest.TestCase):
         no_special_chars = "abc-123"
         no_special_chars_except_space = "abc efg - 123"
 
-        data_dt = "ecephys_2020-10-19T083059"
-        raw_dt = "ecephys_123455_2020-10-19T083059"
-        derived_dt = "ecephys_123455_2020-10-19T083059_sorted_2020-11-21T093158"
-        analyzed_dt = "project_analysis_3033-12-21T042211"
+        data_dt = "ecephys_2020-10-19_08-30-59"
+        raw_dt = "ecephys_123455_2020-10-19_08-30-59"
+        derived_dt = "ecephys_123455_2020-10-19_08-30-59_sorted_2020-11-21_09-31-58"
+        analyzed_dt = "project_analysis_3033-12-21_04-22-11"
 
         self.assertRegex(data, DataRegexLegacy.DATA)
         self.assertRegex(raw, DataRegexLegacy.RAW)
@@ -115,31 +115,22 @@ class TestDataNamePatternsMethods(unittest.TestCase):
 
         dt = datetime(2020, 12, 29, 1, 10, 50)
         actual_output = datetime_to_name_string(dt)
-        self.assertEqual("2020-12-29T011050", actual_output)
+        self.assertEqual("2020-12-29_01-10-50", actual_output)
 
     def test_datetime_with_tz_to_name_string(self):
         """Tests datetime object with timezone is converted to string"""
 
         dt = datetime(2020, 12, 29, 1, 10, 50, tzinfo=timezone.utc)
         actual_output = datetime_to_name_string(dt)
-        self.assertEqual("2020-12-29T011050", actual_output)
+        self.assertEqual("2020-12-29_01-10-50", actual_output)
 
     def test_datetime_from_name_string(self):
         """Tests date and time strings are converted to datetime object"""
 
-        datetime_str = "2020-12-29T011050"
+        datetime_str = "2020-12-29_01-10-50"
         actual_output = datetime_from_name_string(datetime_str)
         dt = datetime(2020, 12, 29, 1, 10, 50)
         self.assertEqual(dt, actual_output)
-
-    def test_deprecated_warning(self):
-        """Tests warning is raised for deprecated method"""
-
-        if sys.version_info.minor <= 10:  # pragma: no cover
-            self.skipTest("DeprecationWarning is not raised in Python 3.10")
-        else:  # pragma: no cover
-            with self.assertWarns(DeprecationWarning):
-                datetime_from_name_string(dt="2020-12-29T100459")
 
     def test_build_data_name(self):
         """Tests datetime object is converted to string and attached to label"""
@@ -148,7 +139,7 @@ class TestDataNamePatternsMethods(unittest.TestCase):
         dt = datetime(2020, 12, 29, 1, 10, 50)
         actual_output = build_data_name(label=subject_id, creation_datetime=dt)
 
-        self.assertEqual("123456_2020-12-29T011050", actual_output)
+        self.assertEqual("123456_2020-12-29_01-10-50", actual_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes two breaking changes:

- It reverts the changes we made to the datetime pattern to use `YYYY-MM-DD_HH-MM-SS` instead of the isoformat compatible plan for 2.0 of `THHMMSS`
- It changes the `AxisDirection.BT` and `TB` to `DU` and `UD`. This is so that there isn't a name clash with the forward-to-back axis, which was causing problem for devices. In the future all axis direction acronyms need to be unique.