### PR TITLE
feat: add StimulusModality

### DIFF
--- a/src/aind_data_schema_models/_generators/models/stimulus_modality.csv
+++ b/src/aind_data_schema_models/_generators/models/stimulus_modality.csv
@@ -1,0 +1,9 @@
+name
+Auditory
+Free moving
+Olfactory
+Optogenetics
+No stimulus
+Virtual reality
+Visual
+Wheel friction

--- a/src/aind_data_schema_models/_generators/templates/stimulus_modality.txt
+++ b/src/aind_data_schema_models/_generators/templates/stimulus_modality.txt
@@ -1,0 +1,11 @@
+"""Stimulus modalities"""
+{% raw -%}
+from enum import Enum
+{% endraw %}
+
+class StimulusModality(str, Enum):
+    """Stimulus modalities"""
+{% for _, row in data.iterrows() %}
+    {{ row['name'] | to_class_name | upper }} = "{{ row['name'] }}"
+{%- endfor %}
+

--- a/src/aind_data_schema_models/stimulus_modality.py
+++ b/src/aind_data_schema_models/stimulus_modality.py
@@ -1,0 +1,16 @@
+"""Stimulus modalities"""
+
+from enum import Enum
+
+
+class StimulusModality(str, Enum):
+    """Stimulus modalities"""
+
+    AUDITORY = "Auditory"
+    FREE_MOVING = "Free moving"
+    NO_STIMULUS = "No stimulus"
+    OLFACTORY = "Olfactory"
+    OPTOGENETICS = "Optogenetics"
+    VIRTUAL_REALITY = "Virtual reality"
+    VISUAL = "Visual"
+    WHEEL_FRICTION = "Wheel friction"

--- a/tests/test_stimulus_modality.py
+++ b/tests/test_stimulus_modality.py
@@ -11,7 +11,7 @@ class TestStimulusModality(unittest.TestCase):
     def test_class_construction(self):
         """Tests enum can be instantiated via string"""
 
-        self.assertEqual(StimulusModality.NO_STIMULUS, StimulusModality("NO_STIMULUS"))
+        self.assertEqual(StimulusModality.NO_STIMULUS, StimulusModality("No stimulus"))
 
 
 if __name__ == "__main__":

--- a/tests/test_stimulus_modality.py
+++ b/tests/test_stimulus_modality.py
@@ -1,0 +1,18 @@
+"""Tests classes in stimulus_modality module"""
+
+import unittest
+
+from aind_data_schema_models.stimulus_modality import StimulusModality
+
+
+class TestStimulusModality(unittest.TestCase):
+    """Tests methods in StimulusModality class"""
+
+    def test_class_construction(self):
+        """Tests enum can be instantiated via string"""
+
+        self.assertEqual(StimulusModality.NO_STIMULUS, StimulusModality("NO_STIMULUS"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR moves StimulusModality from aind-data-schema into the models repo. It also replaces StimulusModality.NONE with StimulusModality.NO_STIMULUS due to a limitation in how the jinja2 templates work.