### PR TITLE
feat: Add Strain.UNKNOWN

### DIFF
--- a/src/aind_data_schema_models/_generators/models/species.csv
+++ b/src/aind_data_schema_models/_generators/models/species.csv
@@ -4,4 +4,5 @@ Homo sapiens,NCBI,NCBI:txid9606,default,,
 Macaca mulatta,NCBI,NCBI:txid9544,default,,
 Mus musculus,NCBI,NCBI:txid10090,C57BL/6J,MGI,MGI:3028467
 Mus musculus,NCBI,NCBI:txid10090,BALB/c,MGI,MGI:2159737
+Mus musculus,NCBI,NCBI:txid10090,Unknown,,
 Rattus norvegicus,NCBI,NCBI:txid10116,default,,

--- a/src/aind_data_schema_models/species.py
+++ b/src/aind_data_schema_models/species.py
@@ -36,12 +36,23 @@ class _Balb_C(StrainModel):
     registry_identifier: Literal["MGI:2159737"] = "MGI:2159737"
 
 
+class _Unknown(StrainModel):
+    """Model Unknown"""
+
+    name: Literal["Unknown"] = "Unknown"
+    species: Literal["Mus musculus"] = "Mus musculus"
+    registry: Registry.ONE_OF = Registry.NAN
+    registry_identifier: Literal["nan"] = "nan"
+
+
 class Strain:
     """Strain"""
 
     C57BL_6J = _C57Bl_6J()
 
     BALB_C = _Balb_C()
+
+    UNKNOWN = _Unknown()
 
     ALL = tuple(StrainModel.__subclasses__())
 


### PR DESCRIPTION
Required for backward compatibility with aind-data-schema v1.0, where Strain was not a required field for mice (it is now required). We will later backfill and remove these wherever possible.