### PR TITLE
fix: PIDName uses Registry instead of BaseName pattern

### DIFF
--- a/src/aind_data_schema_models/pid_names.py
+++ b/src/aind_data_schema_models/pid_names.py
@@ -1,8 +1,9 @@
 """Module for pidname definitions"""
 
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
+from aind_data_schema_models.registries import Registry
 
 
 class BaseName(BaseModel):
@@ -20,5 +21,5 @@ class PIDName(BaseName):
     the registry for that PID, and abbreviation for that registry
     """
 
-    registry: Optional[BaseName] = Field(default=None, title="Registry")
+    registry: Optional[Union[Registry, str]] = Field(default=None, title="Registry")
     registry_identifier: Optional[str] = Field(default=None, title="Registry identifier")


### PR DESCRIPTION
I didn't realize this would be an issue, but anywhere we use PIDName now we need to use either an existing registry from the enum or allow users to specify their own. This is instead of the previous pattern where users could enter any dictionary that matched the `BaseName` pattern which happened to match the `RegistryModel`.