### PR TITLE
Added between-vertebrae origins for spinal injections

### DIFF
--- a/src/aind_data_schema_models/coordinates.py
+++ b/src/aind_data_schema_models/coordinates.py
@@ -16,6 +16,14 @@ class Origin(str, Enum):
     C5 = "C5"
     C6 = "C6"
     C7 = "C7"
+    BETWEEN_C1_C2 = "Between_C1-C2"
+    BETWEEN_C2_C3 = "Between_C2-C3"
+    BETWEEN_C3_C4 = "Between_C3-C4"
+    BETWEEN_C4_C5 = "Between_C4-C5"
+    BETWEEN_C6_C7 = "Between_C6-C7"
+    BETWEEN_C7_C8 = "Between_C7-C8"
+    BETWEEN_C8_T1 = "Between_C8-T1"
+    BETWEEN_T1_T2 = "Between_T1-T2"
     TIP = "Tip"  # of a probe
     FRONT_CENTER = "Front_center"  # front center of a device, e.g. camera
     ARENA_CENTER = "Arena_center"  # center of an arena on the ground surface

--- a/src/aind_data_schema_models/coordinates.py
+++ b/src/aind_data_schema_models/coordinates.py
@@ -9,13 +9,6 @@ class Origin(str, Enum):
     ORIGIN = "Origin"  # only exists in Atlases / Images
     BREGMA = "Bregma"
     LAMBDA = "Lambda"
-    C1 = "C1"  # cervical vertebrae
-    C2 = "C2"
-    C3 = "C3"
-    C4 = "C4"
-    C5 = "C5"
-    C6 = "C6"
-    C7 = "C7"
     BETWEEN_C1_C2 = "Between_C1-C2"
     BETWEEN_C2_C3 = "Between_C2-C3"
     BETWEEN_C3_C4 = "Between_C3-C4"


### PR DESCRIPTION
Adds between-vertebrae origins for spinal injections. This allows us to specify origins for spinal injections that directly align with the way they are specified in the surgical request form.

Closes: https://github.com/AllenNeuralDynamics/aind-data-schema/issues/1564

Should be merged alongside this documentation PR: https://github.com/AllenNeuralDynamics/aind-data-schema/pull/1565
