### PR TITLE
feat: add digital input unitless unit

### DIFF
--- a/src/aind_data_schema_models/units.py
+++ b/src/aind_data_schema_models/units.py
@@ -143,6 +143,7 @@ class UnitlessUnit(str, Enum):
 
     PERCENT = "percent"
     FC = "fraction of cycle"
+    DIGITAL_INPUT = "digital input"
 
 
 UNITS = Union[


### PR DESCRIPTION
Add a UnitlessUnit.DIGITAL_INPUT for digital-to-analog converter inputs (which are arbitrary integer values)