### PR TITLE
fix: update git checkout and add workflow_dispatch in publish to docdb workflows

### DIFF
--- a/.github/workflows/publish_models_dev.yml
+++ b/.github/workflows/publish_models_dev.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - 'src/aind_data_schema_models/_generators/models/**'
+  workflow_dispatch:
 
 jobs:
   publish_models:

--- a/.github/workflows/publish_models_main.yml
+++ b/.github/workflows/publish_models_main.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - 'src/aind_data_schema_models/_generators/models/**'
+  workflow_dispatch:
 
 jobs:
   publish_models:


### PR DESCRIPTION
related to #66 

Update the publish to docdb dev and prod workflows to use checkout v5 action and removes redundant git pull.