### PR TITLE
hotfix: reduce set of acquisition types

### DIFF
--- a/src/aind_data_schema_models/_generators/models/slap2_acquisition_type.csv
+++ b/src/aind_data_schema_models/_generators/models/slap2_acquisition_type.csv
@@ -1,3 +1,3 @@
 name
-integration scan
-raster scan
+integration
+raster

--- a/src/aind_data_schema_models/slap2_acquisition_type.py
+++ b/src/aind_data_schema_models/slap2_acquisition_type.py
@@ -6,5 +6,5 @@ from enum import Enum
 class Slap2AcquisitionType(str, Enum):
     """Stimulus modalities"""
 
-    INTEGRATION_SCAN = "integration scan"
-    RASTER_SCAN = "raster scan"
+    INTEGRATION = "integration"
+    RASTER = "raster"

--- a/tests/test_slap2_acquisition_type.py
+++ b/tests/test_slap2_acquisition_type.py
@@ -11,7 +11,7 @@ class TestSlap2AcquisitionType(unittest.TestCase):
     def test_class_construction(self):
         """Tests enum can be instantiated via string"""
 
-        self.assertEqual(Slap2AcquisitionType.INTEGRATION_SCAN, Slap2AcquisitionType("integration scan"))
+        self.assertEqual(Slap2AcquisitionType.INTEGRATION, Slap2AcquisitionType("integration"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR hotfixes the Slap2AcquisitionType enum to match the team's request