### PR TITLE
fix: remove tamoxifen induction procedure

### DIFF
--- a/src/aind_data_schema_models/_generators/models/specimen_procedure_types.csv
+++ b/src/aind_data_schema_models/_generators/models/specimen_procedure_types.csv
@@ -16,4 +16,3 @@ Sectioning
 Soak
 Storage
 Stripping
-Tamoxifen induction

--- a/src/aind_data_schema_models/specimen_procedure_types.py
+++ b/src/aind_data_schema_models/specimen_procedure_types.py
@@ -23,4 +23,3 @@ class SpecimenProcedureType(str, Enum):
     SOAK = "Soak"
     STORAGE = "Storage"
     STRIPPING = "Stripping"
-    TAMOXIFEN_INDUCTION = "Tamoxifen induction"


### PR DESCRIPTION
This is a breaking change, but it has apparently never been used and can be safely removed from the models repo without breaking existing data assets.